### PR TITLE
Add raise error when http response is not 200

### DIFF
--- a/lib/slack_tsuribari/angler.rb
+++ b/lib/slack_tsuribari/angler.rb
@@ -18,9 +18,9 @@ module SlackTsuribari
 
       def throw_action(hook, payload, auto_detach)
         hook.attach(payload)
-        Connection.new(hook.uri, hook.proxy_setting).post(hook.payload_to_json).tap do
-          hook.detach if auto_detach
-        end
+        Connection.new(hook.uri, hook.setting).post(hook.payload_to_json)
+      ensure
+        hook.detach if auto_detach
       end
     end
   end

--- a/lib/slack_tsuribari/hook.rb
+++ b/lib/slack_tsuribari/hook.rb
@@ -24,12 +24,13 @@ module SlackTsuribari
       :proxy_pass,
       :no_proxy,
       :pre_payload,
+      :raise_error,
       keyword_init: true
     )
 
     class << self
       def config(uri = nil)
-        config = Config.new(pre_payload: PrePayload.new)
+        config = Config.new(pre_payload: PrePayload.new, raise_error: true)
 
         if block_given?
           yield(config)
@@ -52,13 +53,14 @@ module SlackTsuribari
       config.uri
     end
 
-    def proxy_setting
+    def setting
       {
         proxy_addr: config.proxy_addr,
         proxy_port: config.proxy_port,
         proxy_user: config.proxy_user,
         proxy_pass: config.proxy_pass,
-        no_proxy: config.no_proxy
+        no_proxy: config.no_proxy,
+        raise_error: config.raise_error
       }
     end
 

--- a/spec/lib/angler_spec.rb
+++ b/spec/lib/angler_spec.rb
@@ -162,6 +162,9 @@ RSpec.describe SlackTsuribari::Angler do
         let(:payload_result) { JSON.dump({ text: 'something' }) }
         let(:net_http_double) { instance_double(Net::HTTP) }
         let(:response) { Net::HTTPForbidden.new('1.1', '403', 'Forbidden') }
+        let(:raise_response) do
+          RUBY_VERSION < '2.6.0' ? Net::HTTPServerException : Net::HTTPClientException
+        end
 
         before do
           allow(Net::HTTP).to receive(:new) do |host, port, _, _, _, _, _|
@@ -176,7 +179,7 @@ RSpec.describe SlackTsuribari::Angler do
         end
 
         it 'host, port and data is correct and return 403 with raise error' do
-          expect { subject }.to raise_error(Net::HTTPClientException)
+          expect { subject }.to raise_error(raise_response)
           expect(@host_port_result).to eq ['test.co.jp', 443]
           expect(@path_data_result).to eq ['/hook', payload_result]
           expect(hook.payload).to be_nil
@@ -378,6 +381,9 @@ RSpec.describe SlackTsuribari::Angler do
         let(:payload_result) { JSON.dump({ text: 'test' }) }
         let(:net_http_double) { instance_double(Net::HTTP) }
         let(:response) { Net::HTTPForbidden.new('1.1', '403', 'Forbidden') }
+        let!(:raise_response) do
+          RUBY_VERSION < '2.6.0' ? Net::HTTPServerException : Net::HTTPClientException
+        end
 
         before do
           allow(Net::HTTP).to receive(:new) do |host, port, _, _, _, _, _|
@@ -392,7 +398,7 @@ RSpec.describe SlackTsuribari::Angler do
         end
 
         it 'host, port and data is correct and return 403 with raise error' do
-          expect { subject }.to raise_error(Net::HTTPClientException)
+          expect { subject }.to raise_error(raise_response)
           expect(@host_port_result).to eq ['test.co.jp', 443]
           expect(@path_data_result).to eq ['/hook', payload_result]
           expect(hook.payload).to be_nil

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -87,12 +87,15 @@ RSpec.describe SlackTsuribari::Connection do
           let(:response) do
             Net::HTTPForbidden.new('1.1', '403', 'Forbidden')
           end
+          let(:raise_response) do
+            RUBY_VERSION < '2.6.0' ? Net::HTTPServerException : Net::HTTPClientException
+          end
 
           before do
             allow_any_instance_of(Net::HTTP).to receive(:post).and_return(response)
           end
 
-          it { expect { subject }.to raise_error(Net::HTTPClientException) }
+          it { expect { subject }.to raise_error(raise_response) }
         end
       end
 

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -51,14 +51,78 @@ RSpec.describe SlackTsuribari::Connection do
   end
 
   describe '#post' do
-    subject { described_class.new('https://test.co.jp/test').post('{test: 1}') }
+    context 'check value at post' do
+      subject { described_class.new('https://test.co.jp/test').post('{test: 1}') }
 
-    before do
-      allow_any_instance_of(Net::HTTP).to receive(:post) do |_, path, data, header|
-        [path, data, header]
+      before do
+        allow_any_instance_of(Net::HTTP).to receive(:post) do |_, path, data, header|
+          @result = [path, data, header]
+          Net::HTTPOK.new('1.1', 200, 'OK')
+        end
+      end
+
+      it 'receive correct path, date and header' do
+        subject
+        expect(@result).to eq ['/test', '{test: 1}', 'Content-Type' => 'application/json']
       end
     end
 
-    it { is_expected.to eq ['/test', '{test: 1}', 'Content-Type' => 'application/json'] }
+    context 'response case' do
+      context 'when raise_error option is true' do
+        subject { described_class.new('https://test.co.jp/test').post('{test: 1}') }
+
+        context 'when return 2xx' do
+          let(:response) do
+            Net::HTTPOK.new('1.1', '200', 'OK')
+          end
+
+          before do
+            allow_any_instance_of(Net::HTTP).to receive(:post).and_return(response)
+          end
+
+          it { is_expected.to eq response }
+        end
+
+        context 'when return other than 2xx' do
+          let(:response) do
+            Net::HTTPForbidden.new('1.1', '403', 'Forbidden')
+          end
+
+          before do
+            allow_any_instance_of(Net::HTTP).to receive(:post).and_return(response)
+          end
+
+          it { expect { subject }.to raise_error(Net::HTTPClientException) }
+        end
+      end
+
+      context 'when raise_error option is false' do
+        subject { described_class.new('https://test.co.jp/test', { raise_error: false }).post('{test: 1}') }
+
+        context 'when return 2xx' do
+          let(:response) do
+            Net::HTTPOK.new('1.1', '200', 'OK')
+          end
+
+          before do
+            allow_any_instance_of(Net::HTTP).to receive(:post).and_return(response)
+          end
+
+          it { is_expected.to eq response }
+        end
+
+        context 'when return other than 2xx' do
+          let(:response) do
+            Net::HTTPForbidden.new('1.1', '403', 'Forbidden')
+          end
+
+          before do
+            allow_any_instance_of(Net::HTTP).to receive(:post).and_return(response)
+          end
+
+          it { is_expected.to eq response }
+        end
+      end
+    end
   end
 end

--- a/spec/lib/hook_spec.rb
+++ b/spec/lib/hook_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe SlackTsuribari::Hook do
       let(:result) do
         SlackTsuribari::Hook::Config.new(
           uri: 'https://test.co.jp/',
-          pre_payload: SlackTsuribari::Hook::PrePayload.new
+          pre_payload: SlackTsuribari::Hook::PrePayload.new,
+          raise_error: true
         )
       end
 
@@ -102,7 +103,8 @@ RSpec.describe SlackTsuribari::Hook do
       let(:result) do
         SlackTsuribari::Hook::Config.new(
           uri: 'https://test.co.jp/',
-          pre_payload: SlackTsuribari::Hook::PrePayload.new
+          pre_payload: SlackTsuribari::Hook::PrePayload.new,
+          raise_error: true
         )
       end
 
@@ -121,7 +123,8 @@ RSpec.describe SlackTsuribari::Hook do
       let(:result) do
         SlackTsuribari::Hook::Config.new(
           uri: 'https://test.co.jp/',
-          pre_payload: SlackTsuribari::Hook::PrePayload.new('test', 'test')
+          pre_payload: SlackTsuribari::Hook::PrePayload.new('test', 'test'),
+          raise_error: true
         )
       end
 
@@ -135,7 +138,7 @@ RSpec.describe SlackTsuribari::Hook do
     it { is_expected.to eq 'https://test.co.jp/' }
   end
 
-  describe '#proxy_setting' do
+  describe '#setting' do
     subject do
       described_class.config do |config|
         config.uri = 'https://test.co.jp/'
@@ -144,7 +147,8 @@ RSpec.describe SlackTsuribari::Hook do
         config.proxy_user = 'test'
         config.proxy_pass = 'password'
         config.no_proxy = '192.168.1.1'
-      end.proxy_setting
+        config.raise_error = false
+      end.setting
     end
 
     let(:result) do
@@ -153,7 +157,8 @@ RSpec.describe SlackTsuribari::Hook do
         proxy_port: 8080,
         proxy_user: 'test',
         proxy_pass: 'password',
-        no_proxy: '192.168.1.1'
+        no_proxy: '192.168.1.1',
+        raise_error: false
       }
     end
 


### PR DESCRIPTION
Improve the condition that the notification cannot detect failure because no exception is raised even if the HTTP status code other than 200 is returned from slack.